### PR TITLE
Add latest flag for add command

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ cargo install apicurio-cli
 
 2. **Add a dependency:**
    ```bash
-   apicurio add my-registry/com.example/user-service@^1.0.0
+   apicurio add --latest my-registry/com.example/user-service
    ```
 
 3. **Pull dependencies:**
@@ -208,7 +208,7 @@ generatedAt: "1735387200000000000"
 
 | Command | Description |
 |---------|-------------|
-| `add <identifier>` | Add a new dependency (interactive if identifier incomplete) |
+| `add <identifier> [--latest]` | Add a new dependency (interactive if identifier incomplete; `--latest` selects the newest version) |
 | `remove <identifier>` | Remove a dependency by identifier |
 | `list` | List all configured dependencies and registries |
 | `status` | Check for outdated dependencies |
@@ -244,7 +244,7 @@ generatedAt: "1735387200000000000"
 apicurio init
 
 # Add a Protobuf dependency
-apicurio add production/com.example/user-service@^1.0.0
+apicurio add --latest production/com.example/user-service
 
 # Pull dependencies
 apicurio pull
@@ -264,8 +264,8 @@ apicurio registry add prod https://prod-registry.com
 apicurio registry add dev https://dev-registry.com
 
 # Add dependencies from different registries
-apicurio add prod/com.example/users@^1.0.0
-apicurio add dev/com.example/orders@^2.0.0
+apicurio add --latest prod/com.example/users
+apicurio add --latest dev/com.example/orders
 ```
 
 ### Publishing Artifacts

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -72,8 +72,8 @@ Add schema dependencies to your project:
 # Interactive mode - prompts for missing information
 apicurio add
 
-# Specify full identifier
-apicurio add company-prod/com.example.services/user-service@^1.0.0
+# Automatically choose the latest version
+apicurio add --latest company-prod/com.example.services/user-service
 
 # Partial identifier - will prompt for missing parts
 apicurio add user-service@^1.0.0

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -71,6 +71,8 @@ pub enum Commands {
             help = "Dependency identifier in format registry/group_id/artifact_id@version (all parts optional, will prompt for missing)"
         )]
         identifier: Option<String>,
+        #[arg(long, help = "Automatically use the latest available version")]
+        latest: bool,
     },
     #[command(about = "Remove an existing dependency by identifier")]
     Remove {
@@ -124,7 +126,7 @@ pub async fn run(cmd: Commands) -> Result<()> {
         Commands::Pull => pull::run().await,
         Commands::Update => update::run().await,
         Commands::Init => init::run().await,
-        Commands::Add { identifier } => add::run(identifier).await,
+        Commands::Add { identifier, latest } => add::run(identifier, latest).await,
         Commands::Remove { identifier } => remove::run(identifier).await,
         Commands::List => list::run().await,
         Commands::Status => status::run().await,


### PR DESCRIPTION
## Summary
- add a `--latest` flag to `add` subcommand
- auto-select newest version when using `--latest`
- document the new flag in README and TUTORIAL

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6863438e6ce0832aab3475ca05359481